### PR TITLE
feat: add pagination in employee-rest-api-crud

### DIFF
--- a/src/main/java/com/sachin/employee/controller/EmployeeController.java
+++ b/src/main/java/com/sachin/employee/controller/EmployeeController.java
@@ -5,6 +5,7 @@ import com.sachin.employee.service.EmployeeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,6 +40,14 @@ public class EmployeeController {
         logger.info("Fetching employee with ID: {}", id);
         Optional<Employee> employee = employeeService.getEmployeeById(id);
         return ResponseEntity.ok(employee);
+    }
+
+    // GET with pagination
+    @GetMapping("/pagination")
+    public Page<Employee> getPaginatedEmployees(@RequestParam(defaultValue = "0") int page,
+                                              @RequestParam(defaultValue = "3") int size) {
+
+        return employeeService.getEmployeeWithPagination(page, size);
     }
 
     @DeleteMapping("/removeId/{id}")

--- a/src/main/java/com/sachin/employee/service/EmployeeService.java
+++ b/src/main/java/com/sachin/employee/service/EmployeeService.java
@@ -1,6 +1,7 @@
 package com.sachin.employee.service;
 
 import com.sachin.employee.model.Employee;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +15,6 @@ public interface EmployeeService {
     Optional<Employee> getEmployeeById(Integer id);
 
     boolean deleteEmployeeById(Integer id);
+
+    Page<Employee> getEmployeeWithPagination(int page, int size);
 }

--- a/src/main/java/com/sachin/employee/service/impl/EmployeeImpl.java
+++ b/src/main/java/com/sachin/employee/service/impl/EmployeeImpl.java
@@ -6,6 +6,9 @@ import com.sachin.employee.service.EmployeeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -29,6 +32,12 @@ public class EmployeeImpl implements EmployeeService {
     public List<Employee> getAllEmployees() {
         logger.info("Fetching all employees");
         return employeeRepository.findAll();
+    }
+
+    @Override
+    public Page<Employee> getEmployeeWithPagination(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return employeeRepository.findAll(pageable);
     }
 
     @Override


### PR DESCRIPTION
Changes Introduced:
- Added pagination support for the GET /employees endpoint using Spring Data Pageable.
- Default pagination set to page=0 and size=3.
- Returns a Page<Employee> object with metadata (total pages, current page, etc.).